### PR TITLE
fix: cancel dangling timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,13 @@ module.exports = (getKeepAliveValue, options) => {
             sourceNext = source.next()
           }
 
+          let timer
           const timeout = new Promise(resolve => {
-            setTimeout(() => resolve({ value: KEEP_ALIVE }), options.timeout || 1000)
+            timer = setTimeout(() => resolve({ value: KEEP_ALIVE }), options.timeout || 1000)
           })
 
           const { done, value } = await Promise.race([timeout, sourceNext])
+          clearTimeout(timer)
 
           if (done) return { done }
 


### PR DESCRIPTION
If a large timeout value is set but the source iterable returns soon, the library causes Node.js to hang until the timeout has elapsed. This commit fixes this problem by canceling the timer.

Use the following snippet to reproduce the bug:
```js
const keepAlive = require('.')

async function * source () {
  yield 0
}

(async () => {
  const iterable = keepAlive(() => 1, { timeout: 10000 })(source())

  for await (const item of iterable) {
    console.log(item)
  }

  console.log('Program should exit now')
})()
```

I'm unable to create a test case for this, because the test framework seems to terminate the process even if the internal timer is not canceled.